### PR TITLE
feat: consolidate signup endpoints into unified endpoint Issue #4

### DIFF
--- a/server/src/docs/authentication.md
+++ b/server/src/docs/authentication.md
@@ -20,9 +20,9 @@ The LeetcodeTracker application now includes a comprehensive JWT-based authentic
 
 ## Authentication Endpoints
 
-### 1. User Signup
+### 1. Signup (Unified Endpoint)
 ```
-POST /auth/signup
+POST /api/v1/auth/signup
 ```
 
 **Request Body:**
@@ -30,7 +30,29 @@ POST /auth/signup
 {
   "username": "string (required)",
   "email": "string (required)",
-  "password": "string (required)"
+  "password": "string (required)",
+  "role": "string (optional, USER or ADMIN, defaults to USER)"
+}
+```
+
+**Examples:**
+
+**User Signup (default):**
+```json
+{
+  "username": "john_doe",
+  "email": "john@example.com",
+  "password": "securePassword123"
+}
+```
+
+**Admin Signup:**
+```json
+{
+  "username": "admin_user",
+  "email": "admin@example.com",
+  "password": "adminPassword123",
+  "role": "ADMIN"
 }
 ```
 
@@ -42,41 +64,14 @@ POST /auth/signup
     "userId": "uuid",
     "username": "string",
     "email": "string",
-    "role": "USER"
+    "role": "USER|ADMIN"
   }
 }
 ```
 
-### 2. Admin Signup
+### 2. Login
 ```
-POST /auth/signup/admin
-```
-
-**Request Body:**
-```json
-{
-  "username": "string (required)",
-  "email": "string (required)",
-  "password": "string (required)"
-}
-```
-
-**Response:**
-```json
-{
-  "message": "User registered successfully",
-  "user": {
-    "userId": "uuid",
-    "username": "string",
-    "email": "string",
-    "role": "ADMIN"
-  }
-}
-```
-
-### 3. Login
-```
-POST /auth/login
+POST /api/v1/auth/login
 ```
 
 **Request Body:**

--- a/server/src/main/java/com/leetcodetracker/code/controller/AuthController.java
+++ b/server/src/main/java/com/leetcodetracker/code/controller/AuthController.java
@@ -19,26 +19,22 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<Map<String, Object>> signup(@RequestBody SignupRequest request) {
         try {
+            // Determine role from request, default to USER if not specified or invalid
+            UserRole role = UserRole.USER; // Default role
+            if (request.getRole() != null && !request.getRole().trim().isEmpty()) {
+                try {
+                    role = UserRole.valueOf(request.getRole().toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    // Invalid role provided, use default USER role
+                    role = UserRole.USER;
+                }
+            }
+            
             Map<String, Object> response = authenticationService.signup(
                     request.getUsername(),
                     request.getEmail(),
                     request.getPassword(),
-                    UserRole.USER // Default role for signup
-            );
-            return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        }
-    }
-
-    @PostMapping("/signup/admin")
-    public ResponseEntity<Map<String, Object>> signupAdmin(@RequestBody SignupRequest request) {
-        try {
-            Map<String, Object> response = authenticationService.signup(
-                    request.getUsername(),
-                    request.getEmail(),
-                    request.getPassword(),
-                    UserRole.ADMIN
+                    role
             );
             return ResponseEntity.ok(response);
         } catch (RuntimeException e) {
@@ -64,6 +60,7 @@ public class AuthController {
         private String username;
         private String email;
         private String password;
+        private String role; // Optional role field (USER or ADMIN)
 
         // Getters and setters
         public String getUsername() { return username; }
@@ -72,6 +69,8 @@ public class AuthController {
         public void setEmail(String email) { this.email = email; }
         public String getPassword() { return password; }
         public void setPassword(String password) { this.password = password; }
+        public String getRole() { return role; }
+        public void setRole(String role) { this.role = role; }
     }
 
     public static class LoginRequest {


### PR DESCRIPTION
- Remove separate /signup/admin endpoint
- Add optional role field to SignupRequest DTO
- Update signup endpoint to handle USER/ADMIN roles
- Default to USER role if not specified or invalid
- Update authentication documentation with new structure
- Simplify API by having single signup endpoint